### PR TITLE
fix compile error in the latest nightly 1.33.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.1.0"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "spin 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -31,7 +31,7 @@ name = "lazy_static"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "spin 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -45,7 +45,7 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -73,7 +73,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
-"checksum spin 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "dc28a8d2f2efa706fc9d3d074e265c1d529db41c1603679861662cb88e05e70a"
+"checksum spin 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "37b5646825922b96b5d7d676b5bb3458a54498e96ed7b0ce09dc43a07038fea4"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ crate-type = ["staticlib"]
 
 [dependencies]
 lazy_static = { version = "1.0.0", features = ["spin_no_std"] }
-spin = "0.4.7"
+spin = "0.4.9"
 rand = { version = "0.4.2", default-features = false }

--- a/kbuild.mk
+++ b/kbuild.mk
@@ -32,7 +32,7 @@ $(obj)/$(RUST_TARGET): $(RUST_FILES) $(LLVM_TARGET_SPEC) $(BASE_DIR)/$(KBUILD)
 # directory but subsequent invokations of cargo/xargo/rustc might change their working directory. Setting
 # RUST_TARGET_PATH ensures that the compiler can find the LLVM target specification.
 # We also have to `cd` into $(BASE_DIR) since we are currently in the kernel headers directory.
-	(cd $(BASE_DIR); env RUST_TARGET_PATH=$(BASE_DIR) $(XARGO) rustc $(if $(RELEASE),--release) $(if $(VERBOSE),--verbose) --target $(UTS_MACHINE)-unknown-none-gnu -- -C code-model=kernel -C relocation-model=static -C panic=abort)
+	(cd $(BASE_DIR); env RUST_TARGET_PATH=$(BASE_DIR) $(CARGO) xbuild $(if $(RELEASE),--release) $(if $(VERBOSE),--verbose) --target $(UTS_MACHINE)-unknown-none-gnu)
 # After the archive is compiled, copy it to the build directory
 	cp "$(CARGO_BUILD_DIR)/$(RUST_TARGET)" $(obj)
 

--- a/src/io/mod.rs
+++ b/src/io/mod.rs
@@ -1,4 +1,5 @@
 use alloc::*;
+use alloc::vec::Vec;
 use core::fmt;
 use spin::Mutex;
 

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,5 +1,9 @@
 use core::panic::PanicInfo;
 
+#[lang = "eh_personality"]
+#[no_mangle]
+pub extern "C" fn eh_personality() {}
+
 #[allow(dead_code)]
 extern "C" {
     fn abort() -> !;

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -1,36 +1,34 @@
-use core;
-
-// These functions and traits are used by the compiler, but not
-// for a bare-bones hello world. These are normally
-// provided by libstd.
-#[lang = "eh_personality"]
-#[no_mangle]
-pub extern "C" fn eh_personality() {}
-
-#[lang = "eh_unwind_resume"]
-#[no_mangle]
-pub extern "C" fn eh_unwind_resume(_a: *const u8) {}
+use core::panic::PanicInfo;
 
 #[allow(dead_code)]
 extern "C" {
-    fn abort();
+    fn abort() -> !;
     fn panic_c();
 }
 
-#[lang = "panic_fmt"]
+#[panic_handler]
 #[no_mangle]
-pub extern "C" fn rust_begin_panic(msg: core::fmt::Arguments, file: &'static str, line: u32) -> ! {
-    use super::io;
+pub fn rust_begin_panic(info: &PanicInfo) -> ! {
     // Print the file and line number
-    println!("Rust panic @ {}:{}", file, line);
+    if let Some(location) = info.location() {
+        println!("Rust panic @ {}:{}",
+            location.file(), location.line());
+    }
 
     // Print the message and a newline
-    io::print(msg);
-    println!("");
+    if let Some(message) = info.message() {
+        println!("{}", message);
+    }
 
     unsafe {
         // In a real kernel module, we should use abort() instead of panic()
-        abort(); // replace with panic_c() if you want
+        abort() // replace with panic_c() if you want
     }
-    loop {}
+}
+
+use core::alloc::Layout;
+#[cfg(not(test))]
+#[alloc_error_handler]
+pub fn alloc_error(_: Layout) -> ! {
+    unsafe { abort() }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,9 @@
 // Used for dynamic allocation
 #![feature(alloc)]
 #![feature(allocator_api)]
-#![feature(global_allocator)]
+#![feature(alloc_error_handler)]
 #![feature(const_fn)]
+#![feature(panic_info_message)]
 extern crate alloc;
 // Memory-related functions are in the `mem` module
 mod mem;

--- a/x86_64-unknown-none-gnu.json
+++ b/x86_64-unknown-none-gnu.json
@@ -1,5 +1,5 @@
 {
-    "pre-link-args": ["-m64"],
+    "pre-link-args": { "ld": ["-m64"]},
     "data-layout": "e-p:64:64:64-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:64:64-f32:32:32-f64:64:64-v64:64:64-v128:128:128-a0:0:64-s0:64:64-f80:128:128-n8:16:32:64-S128",
     "llvm-target": "x86_64-unknown-none-gnu",
     "target-endian": "little",


### PR DESCRIPTION
Hi Souvik,
Thank you for your email.

First of all, I really love this humorous but challenging project.
And I am pleased to contribute to this project.

BTW, I found that the latest xargo is something wrong.
When I try to build the project using xargo, the following error occurs:

```
$ make
   Updating crates.io index
   Compiling cc v1.0.28
...
error[E0463]: can't find crate for `std`
  |
  = note: the `x86_64-unknown-none-gnu` target may not be installed

error: aborting due to previous error

For more information about this error, try `rustc --explain E0463`.
error: Could not compile `rustc-std-workspace-core`.
warning: build failed, waiting for other jobs to finish...
error: build failed
...
```

I'm not sure the cause.
Instead, I use `cargo xbuild` that looks like working fine.

Here is my current compiler version

```
rustc 1.33.0-nightly (4c2be9c97 2019-01-22)
cargo 1.33.0-nightly (907c0febe 2019-01-20)
xargo 0.3.12 # this won't work!
```

I'll investigate this xargo matter.

thanks,
